### PR TITLE
Fix scaling and rendering issues

### DIFF
--- a/src/main/java/carcassonne/model/tile/TileUtil.java
+++ b/src/main/java/carcassonne/model/tile/TileUtil.java
@@ -2,8 +2,8 @@ package carcassonne.model.tile;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import carcassonne.settings.GameSettings;
 
@@ -12,7 +12,7 @@ import carcassonne.settings.GameSettings;
  * @author Timur Saglam
  */
 public final class TileUtil {
-    private final static Map<TileType, Integer> rotations = new HashMap<>();
+    private final static Map<TileType, Integer> rotations = new ConcurrentHashMap<>();
 
     private TileUtil() {
         throw new IllegalStateException(); // private constructor for non-instantiability
@@ -20,6 +20,7 @@ public final class TileUtil {
 
     /**
      * Determines how often a tile of a specific {@link TileType} can be rotated before it returns to the first rotation.
+     * Method is thread-safe.
      * @param type is the specific {@link TileType}.
      * @return the number of possible rotations (between 1 and 3).
      */

--- a/src/main/java/carcassonne/settings/GameSettings.java
+++ b/src/main/java/carcassonne/settings/GameSettings.java
@@ -25,7 +25,7 @@ public class GameSettings {
     public static final int MAXIMAL_PLAYERS = 5;
     public static final int MAXIMAL_TILES_ON_HAND = 5;
     public static final int TILE_RESOLUTION = 500;
-    public static final int HIGH_DPI_FACTOR = 2; // maximum supported DPI factor.
+    public static final double[] HIGH_DPI_FACTORS = {1.25, 1.5, 1.75, 2.0}; // multi resolution image DPI factors.
     public static final int MAXIMAL_MEEPLES = 7;
 
     // STRING CONSTANTS

--- a/src/main/java/carcassonne/settings/GameSettings.java
+++ b/src/main/java/carcassonne/settings/GameSettings.java
@@ -80,8 +80,8 @@ public class GameSettings {
         numberOfPlayers = 2;
         tilesPerPlayer = 1;
         stackSizeMultiplier = 1;
-        gridWidth = 29;
-        gridHeight = 19;
+        gridWidth = 45;
+        gridHeight = 27;
         allowEnclaves = true;
         changeListeners = new ArrayList<>();
     }

--- a/src/main/java/carcassonne/util/CachedImage.java
+++ b/src/main/java/carcassonne/util/CachedImage.java
@@ -1,33 +1,20 @@
 package carcassonne.util;
 
 import java.awt.Image;
+import java.util.Objects;
 
 /**
- * Data objects to cache images with their scaling information.s
+ * Data object to cache images with their scaling information.
+ * @param image the cached image, cannot be null
+ * @param isPreview whether this image was scaled as a preview image or not
  * @author Timur Saglam
  */
-public class CachedImage {
-    private final Image image;
-    private final boolean preview;
+public record CachedImage(Image image, boolean isPreview) {
 
     /**
-     * Creates
-     * @param image the image to cache, cannot be null.
-     * @param preview whether this image was scaled as a preview image or not.
+     * Compact constructor with validation.
      */
-    public CachedImage(Image image, boolean preview) {
-        if (image == null) {
-            throw new IllegalArgumentException("Cached image cannot be null!");
-        }
-        this.image = image;
-        this.preview = preview;
-    }
-
-    public Image getImage() {
-        return image;
-    }
-
-    public boolean isPreview() {
-        return preview;
+    public CachedImage {
+        Objects.requireNonNull(image, "Cached image cannot be null!");
     }
 }

--- a/src/main/java/carcassonne/util/ConcurrentTileImageScaler.java
+++ b/src/main/java/carcassonne/util/ConcurrentTileImageScaler.java
@@ -51,18 +51,27 @@ public final class ConcurrentTileImageScaler {
     }
 
     /**
-     * Returns the scaled multi-resolution image of a tile. This image therefore supports HighDPI graphics such as Retina on
-     * macOS. This method is thread safe and leverages caching.
-     * @param tile is the tile whose image is required.
-     * @param targetSize is the edge length of the (quadratic) image in pixels.
-     * @param fastScaling specifies whether a fast scaling algorithm should be used.
-     * @return the scaled multi-resolution {@link Image}.
+     * Returns a scaled multi-resolution image of a tile supporting HighDPI displays (e.g., Retina). This method is
+     * thread-safe and leverages caching.
+     * @param tile the tile whose image is required
+     * @param targetSize the edge length of the quadratic image in pixels
+     * @param fastScaling whether to use a fast scaling algorithm
+     * @return the scaled multi-resolution {@link Image}
      */
     public static Image getScaledMultiResolutionImage(Tile tile, int targetSize, boolean fastScaling) {
-        int highDpiSize = Math.min(targetSize * GameSettings.HIGH_DPI_FACTOR, GameSettings.TILE_RESOLUTION);
-        Image highDpiImage = getScaledImage(tile, highDpiSize, fastScaling);
-        Image defaultImage = getScaledImage(tile, targetSize, fastScaling);
-        return new BaseMultiResolutionImage(defaultImage, highDpiImage);
+        double[] factors = GameSettings.HIGH_DPI_FACTORS;
+        Image[] images = new Image[factors.length + 1];
+
+        // Base resolution image
+        images[0] = getScaledImage(tile, targetSize, fastScaling);
+
+        // Higher resolution variants
+        for (int i = 0; i < factors.length; i++) {
+            int scaledSize = (int) Math.round(targetSize * factors[i]);
+            images[i + 1] = getScaledImage(tile, Math.min(scaledSize, GameSettings.TILE_RESOLUTION), fastScaling);
+        }
+
+        return new BaseMultiResolutionImage(images);
     }
 
     /**

--- a/src/main/java/carcassonne/util/ConcurrentTileImageScaler.java
+++ b/src/main/java/carcassonne/util/ConcurrentTileImageScaler.java
@@ -39,13 +39,17 @@ public final class ConcurrentTileImageScaler {
         int lockKey = createKey(tile, targetSize);
         semaphores.putIfAbsent(lockKey, new Semaphore(SINGLE_PERMIT));
         Semaphore lock = semaphores.get(lockKey);
+        boolean acquired = false;
         try {
             lock.acquire();
+            acquired = true;
             return getScaledImageUnsafe(tile, targetSize, fastScaling);
         } catch (InterruptedException exception) {
             exception.printStackTrace();
         } finally {
-            lock.release();
+            if (acquired) {
+                lock.release();
+            }
         }
         return null;
     }

--- a/src/main/java/carcassonne/util/LRUHashMap.java
+++ b/src/main/java/carcassonne/util/LRUHashMap.java
@@ -13,7 +13,7 @@ public class LRUHashMap<K, V> extends LinkedHashMap<K, V> {
 
     private static final float LOAD_FACTOR = 0.75f; // default for LinkedHashMap
     private static final int INITIAL_SIZE = 100;
-    private static final int MAXIMUM_SIZE = 2000;
+    private static final int MAXIMUM_SIZE = 10_000;
     private static final long serialVersionUID = -7078586519346306608L;
 
     /**

--- a/src/main/java/carcassonne/util/TileImageScalingCache.java
+++ b/src/main/java/carcassonne/util/TileImageScalingCache.java
@@ -1,7 +1,8 @@
 package carcassonne.util;
 
 import java.awt.Image;
-import java.util.HashMap;
+import java.util.Collections;
+import java.util.Map;
 
 import carcassonne.model.tile.Tile;
 
@@ -12,7 +13,7 @@ import carcassonne.model.tile.Tile;
  */
 public final class TileImageScalingCache {
     private static final int SHIFT_VALUE = 1000;
-    private static final HashMap<Integer, CachedImage> cachedImages = new LRUHashMap<>();
+    private static final Map<Integer, CachedImage> cachedImages = Collections.synchronizedMap(new LRUHashMap<>());
 
     private TileImageScalingCache() {
         // private constructor ensures non-instantiability!

--- a/src/main/java/carcassonne/util/TileImageScalingCache.java
+++ b/src/main/java/carcassonne/util/TileImageScalingCache.java
@@ -31,7 +31,8 @@ public final class TileImageScalingCache {
         if (previewAllowed) {
             return cachedImages.containsKey(key);
         }
-        return cachedImages.containsKey(key) && !cachedImages.get(key).isPreview();
+        CachedImage image = cachedImages.get(key);
+        return image != null && !image.isPreview();
     }
 
     /**
@@ -41,7 +42,11 @@ public final class TileImageScalingCache {
      * @return the scaled image or null if there is none.
      */
     public static Image getScaledImage(Tile tile, int size) {
-        return cachedImages.get(createKey(tile, size)).image();
+        CachedImage cachedImage = cachedImages.get(createKey(tile, size));
+        if (cachedImage == null) {
+            return null;
+        }
+        return cachedImage.image();
     }
 
     /**

--- a/src/main/java/carcassonne/util/TileImageScalingCache.java
+++ b/src/main/java/carcassonne/util/TileImageScalingCache.java
@@ -41,7 +41,7 @@ public final class TileImageScalingCache {
      * @return the scaled image or null if there is none.
      */
     public static Image getScaledImage(Tile tile, int size) {
-        return cachedImages.get(createKey(tile, size)).getImage();
+        return cachedImages.get(createKey(tile, size)).image();
     }
 
     /**

--- a/src/main/java/carcassonne/view/main/MainView.java
+++ b/src/main/java/carcassonne/view/main/MainView.java
@@ -24,6 +24,7 @@ import carcassonne.view.PaintShop;
 import carcassonne.view.menubar.MainMenuBar;
 import carcassonne.view.menubar.Scoreboard;
 import carcassonne.view.util.LookAndFeelUtil;
+import carcassonne.view.util.ZoomConfig;
 
 /**
  * The main user interface, showing the grid and the menu bar.
@@ -31,13 +32,6 @@ import carcassonne.view.util.LookAndFeelUtil;
  */
 public class MainView extends JFrame implements NotifiableView {
     private static final long serialVersionUID = 5684446992452298030L; // generated UID
-
-    // ZOOM CONSTANTS:
-    private static final int DEFAULT_ZOOM_LEVEL = 125;
-    private static final int MAX_ZOOM_LEVEL = 300;
-    private static final int MIN_ZOOM_LEVEL = 25;
-    private static final int ZOOM_STEP_LARGE = 25;
-    private static final int ZOOM_STEP_SMALL = 5;
 
     // UI CONSTANTS:
     private static final Dimension MINIMAL_WINDOW_SIZE = new Dimension(640, 480);
@@ -61,7 +55,7 @@ public class MainView extends JFrame implements NotifiableView {
         this.controller = controller;
         gridWidth = controller.getSettings().getGridWidth();
         gridHeight = controller.getSettings().getGridHeight();
-        zoomLevel = DEFAULT_ZOOM_LEVEL;
+        zoomLevel = ZoomConfig.DEFAULT_LEVEL.pixels();
         buildFrame();
     }
 
@@ -159,8 +153,8 @@ public class MainView extends JFrame implements NotifiableView {
      * @param mode determines the zoom mode, which affects image quality and performance.
      */
     public synchronized void zoomIn(ZoomMode mode) {
-        if (zoomLevel < MAX_ZOOM_LEVEL) {
-            zoomLevel += mode == FAST ? ZOOM_STEP_SMALL : ZOOM_STEP_LARGE;
+        if (zoomLevel < ZoomConfig.MAX_LEVEL.pixels()) {
+            zoomLevel += mode == FAST ? ZoomConfig.STEP_SMALL.pixels() : ZoomConfig.STEP.pixels();
             updateToChangedZoomLevel(mode);
             menuBar.getZoomSlider().setValueSneakily(zoomLevel); // ensures the slider is updated when using key bindings.
         }
@@ -171,8 +165,8 @@ public class MainView extends JFrame implements NotifiableView {
      * @param mode determines the zoom mode, which affects image quality and performance.
      */
     public synchronized void zoomOut(ZoomMode mode) {
-        if (zoomLevel > MIN_ZOOM_LEVEL) {
-            zoomLevel -= mode == FAST ? ZOOM_STEP_SMALL : ZOOM_STEP_LARGE;
+        if (zoomLevel > ZoomConfig.MIN_LEVEL.pixels()) {
+            zoomLevel -= mode == FAST ? ZoomConfig.STEP_SMALL.pixels() : ZoomConfig.STEP.pixels();
             updateToChangedZoomLevel(mode);
             menuBar.getZoomSlider().setValueSneakily(zoomLevel); // ensures the slider is updated when using key bindings.
         }
@@ -184,7 +178,7 @@ public class MainView extends JFrame implements NotifiableView {
      * @param mode determines the zoom mode, which affects image quality and performance.
      */
     public synchronized void setZoom(int level, ZoomMode mode) {
-        if (level <= MAX_ZOOM_LEVEL && level >= MIN_ZOOM_LEVEL) {
+        if (level <= ZoomConfig.MAX_LEVEL.pixels() && level >= ZoomConfig.MIN_LEVEL.pixels()) {
             zoomLevel = level;
             updateToChangedZoomLevel(mode);
         }

--- a/src/main/java/carcassonne/view/main/MainView.java
+++ b/src/main/java/carcassonne/view/main/MainView.java
@@ -4,6 +4,7 @@ import static carcassonne.view.main.ZoomMode.FAST;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.Toolkit;
 
 import javax.swing.ActionMap;
 import javax.swing.ImageIcon;
@@ -314,8 +315,12 @@ public class MainView extends JFrame implements NotifiableView {
         scrollPane.addZoomListener(() -> zoomIn(FAST), () -> zoomOut(FAST));
         add(scrollPane, BorderLayout.CENTER);
         setMinimumSize(MINIMAL_WINDOW_SIZE);
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        int width = (int) Math.max(screenSize.width * 0.6, MINIMAL_WINDOW_SIZE.getWidth());
+        int height = (int) Math.max(screenSize.height * 0.7, MINIMAL_WINDOW_SIZE.getHeight());
         addWindowListener(new WindowMaximizationAdapter(this));
         pack();
+        setPreferredSize(new Dimension(width, height)); // should be set after maximization
     }
 
     private void checkCoordinates(int x, int y) {

--- a/src/main/java/carcassonne/view/main/MainView.java
+++ b/src/main/java/carcassonne/view/main/MainView.java
@@ -4,7 +4,9 @@ import static carcassonne.view.main.ZoomMode.FAST;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.Frame;
 import java.awt.Toolkit;
+import java.util.Objects;
 
 import javax.swing.ActionMap;
 import javax.swing.ImageIcon;
@@ -35,6 +37,7 @@ public class MainView extends JFrame implements NotifiableView {
 
     // UI CONSTANTS:
     private static final Dimension MINIMAL_WINDOW_SIZE = new Dimension(640, 480);
+    public static final double DEFAULT_SIZE_RATIO = 0.7;
 
     // FIELDS:
     private final ControllerFacade controller;
@@ -310,10 +313,11 @@ public class MainView extends JFrame implements NotifiableView {
         add(scrollPane, BorderLayout.CENTER);
         setMinimumSize(MINIMAL_WINDOW_SIZE);
         Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
-        int width = (int) Math.max(screenSize.width * 0.6, MINIMAL_WINDOW_SIZE.getWidth());
-        int height = (int) Math.max(screenSize.height * 0.7, MINIMAL_WINDOW_SIZE.getHeight());
-        setSize(new Dimension(width, height)); // should be set after maximization
-        addWindowListener(new WindowMaximizationAdapter(this));
+        int width = (int) Math.max(screenSize.width * DEFAULT_SIZE_RATIO, MINIMAL_WINDOW_SIZE.getWidth());
+        int height = (int) Math.max(screenSize.height * DEFAULT_SIZE_RATIO, MINIMAL_WINDOW_SIZE.getHeight());
+        setExtendedState(getExtendedState() | Frame.MAXIMIZED_BOTH);
+        setPreferredSize(new Dimension(width, height));
+        addWindowListener(new WindowMaximizationAdapter(this)); // fix for Windows
         pack();
     }
 
@@ -325,9 +329,7 @@ public class MainView extends JFrame implements NotifiableView {
 
     private void checkParameters(Object... parameters) {
         for (Object parameter : parameters) {
-            if (parameter == null) {
-                throw new IllegalArgumentException("Parameters such as Tile, Meeple, and Player cannot be null!");
-            }
+            Objects.requireNonNull(parameter, "Parameters such as Tile, Meeple, and Player cannot be null!");
         }
     }
 }

--- a/src/main/java/carcassonne/view/main/MainView.java
+++ b/src/main/java/carcassonne/view/main/MainView.java
@@ -318,9 +318,9 @@ public class MainView extends JFrame implements NotifiableView {
         Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
         int width = (int) Math.max(screenSize.width * 0.6, MINIMAL_WINDOW_SIZE.getWidth());
         int height = (int) Math.max(screenSize.height * 0.7, MINIMAL_WINDOW_SIZE.getHeight());
+        setSize(new Dimension(width, height)); // should be set after maximization
         addWindowListener(new WindowMaximizationAdapter(this));
         pack();
-        setPreferredSize(new Dimension(width, height)); // should be set after maximization
     }
 
     private void checkCoordinates(int x, int y) {

--- a/src/main/java/carcassonne/view/main/TileLayer.java
+++ b/src/main/java/carcassonne/view/main/TileLayer.java
@@ -60,8 +60,12 @@ public class TileLayer extends JPanel {
      * @param preview determines if the tiles are rendered in preview mode (fast but ugly).
      */
     public void changeZoomLevel(int zoomLevel, boolean preview) {
-        tileLabels.parallelStream().forEach(it -> it.getTile().getScaledIcon(zoomLevel)); // preload scaled images
+        // Preload scaled images in parallel (no UI modification)
+        tileLabels.parallelStream().forEach(it -> it.getTile().getScaledIcon(zoomLevel));
+
+        setIgnoreRepaint(true);
         tileLabels.forEach(it -> it.setTileSize(zoomLevel, preview));
+        setIgnoreRepaint(false);
     }
 
     /**

--- a/src/main/java/carcassonne/view/main/WindowMaximizationAdapter.java
+++ b/src/main/java/carcassonne/view/main/WindowMaximizationAdapter.java
@@ -31,6 +31,5 @@ public class WindowMaximizationAdapter extends WindowAdapter {
             maximized = true;
             frame.setExtendedState(frame.getExtendedState() | Frame.MAXIMIZED_BOTH);
         }
-
     }
 }

--- a/src/main/java/carcassonne/view/main/WindowMaximizationAdapter.java
+++ b/src/main/java/carcassonne/view/main/WindowMaximizationAdapter.java
@@ -13,6 +13,9 @@ import javax.swing.JFrame;
  * @author Timur Saglam
  */
 public class WindowMaximizationAdapter extends WindowAdapter {
+    private static final String OS_NAME_KEY = "os.name";
+    private static final String WINDOWS = "Windows";
+
     private final JFrame frame;
     private boolean maximized;
 
@@ -27,7 +30,7 @@ public class WindowMaximizationAdapter extends WindowAdapter {
 
     @Override
     public void windowActivated(WindowEvent event) {
-        if (!maximized) {
+        if (!maximized && System.getProperty(OS_NAME_KEY).startsWith(WINDOWS)) {
             maximized = true;
             frame.setExtendedState(frame.getExtendedState() | Frame.MAXIMIZED_BOTH);
         }

--- a/src/main/java/carcassonne/view/menubar/ZoomSlider.java
+++ b/src/main/java/carcassonne/view/menubar/ZoomSlider.java
@@ -17,7 +17,7 @@ public class ZoomSlider extends JSlider {
 
     // UI CONSTANTS:
     private static final int MAJOR_TICK = 64;
-    private static final int MINOR_TICK = 8;
+    private static final int MINOR_TICK = 4;
     private static final String ZOOM_OUT = "Zoom Out (-)";
     private static final String ZOOM_IN = "Zoom In (+)";
 

--- a/src/main/java/carcassonne/view/menubar/ZoomSlider.java
+++ b/src/main/java/carcassonne/view/menubar/ZoomSlider.java
@@ -17,7 +17,7 @@ public class ZoomSlider extends JSlider {
 
     // UI CONSTANTS:
     private static final int MAJOR_TICK = 64;
-    private static final int MINOR_TICK = 4;
+    private static final int MINOR_TICK = 8;
     private static final String ZOOM_OUT = "Zoom Out (-)";
     private static final String ZOOM_IN = "Zoom In (+)";
 

--- a/src/main/java/carcassonne/view/menubar/ZoomSlider.java
+++ b/src/main/java/carcassonne/view/menubar/ZoomSlider.java
@@ -6,6 +6,7 @@ import javax.swing.SwingConstants;
 
 import carcassonne.view.main.MainView;
 import carcassonne.view.main.ZoomMode;
+import carcassonne.view.util.ZoomConfig;
 
 /**
  * Custom {@link JSlider} for the zoom functionality. Additionally, this class creates the zoom in/out menu items.
@@ -14,14 +15,9 @@ import carcassonne.view.main.ZoomMode;
 public class ZoomSlider extends JSlider {
     private static final long serialVersionUID = -5518487902213410121L;
 
-    // SEMANTIC CONSTANTS:
-    private static final int MAXIMUM_VALUE = 300;
-    private static final int MINIMUM_VALUE = 25;
-    private static final int SLIDER_STEP_SIZE = 25;
-
     // UI CONSTANTS:
-    private static final int MAJOR_TICK = 50;
-    private static final int MINOR_TICK = 5;
+    private static final int MAJOR_TICK = 64;
+    private static final int MINOR_TICK = 8;
     private static final String ZOOM_OUT = "Zoom Out (-)";
     private static final String ZOOM_IN = "Zoom In (+)";
 
@@ -35,7 +31,7 @@ public class ZoomSlider extends JSlider {
      * @param mainView is the correlating main user interface.f
      */
     public ZoomSlider(MainView mainView) {
-        super(MINIMUM_VALUE, MAXIMUM_VALUE, mainView.getZoom());
+        super(ZoomConfig.MIN_LEVEL.pixels(), ZoomConfig.MAX_LEVEL.pixels(), mainView.getZoom());
         setPaintTicks(true);
         setOrientation(SwingConstants.VERTICAL);
         setMinorTickSpacing(MINOR_TICK);
@@ -47,11 +43,11 @@ public class ZoomSlider extends JSlider {
         zoomIn = new JMenuItem(ZOOM_IN);
         zoomOut = new JMenuItem(ZOOM_OUT);
         zoomIn.addActionListener(event -> {
-            setValueSneakily(getValue() + SLIDER_STEP_SIZE);
+            setValueSneakily(getValue() + ZoomConfig.STEP.pixels());
             mainView.zoomIn(ZoomMode.SMOOTH);
         });
         zoomOut.addActionListener(event -> {
-            setValueSneakily(getValue() - SLIDER_STEP_SIZE);
+            setValueSneakily(getValue() - ZoomConfig.STEP.pixels());
             mainView.zoomOut(ZoomMode.SMOOTH);
         });
     }

--- a/src/main/java/carcassonne/view/menubar/ZoomSliderListener.java
+++ b/src/main/java/carcassonne/view/menubar/ZoomSliderListener.java
@@ -17,7 +17,7 @@ import carcassonne.view.main.ZoomMode;
  */
 public class ZoomSliderListener extends MouseAdapter implements ChangeListener {
 
-    private static final double SMOOTHING_FACTOR = 5.0; // only update zoom with this step size.
+    private static final double SMOOTHING_FACTOR = 4.0; // only update zoom with this step size.
     private final MainView mainView;
     private final JSlider slider;
     private int previousValue;

--- a/src/main/java/carcassonne/view/menubar/ZoomSliderListener.java
+++ b/src/main/java/carcassonne/view/menubar/ZoomSliderListener.java
@@ -9,6 +9,7 @@ import javax.swing.event.ChangeListener;
 
 import carcassonne.view.main.MainView;
 import carcassonne.view.main.ZoomMode;
+import carcassonne.view.util.ZoomConfig;
 
 /**
  * Smoothing event and mouse listener for the zoom slider, which smoothes the dragging by limiting the updates to
@@ -17,7 +18,7 @@ import carcassonne.view.main.ZoomMode;
  */
 public class ZoomSliderListener extends MouseAdapter implements ChangeListener {
 
-    private static final double SMOOTHING_FACTOR = 8.0; // only update zoom with this step size.
+    private static final double SMOOTHING_FACTOR = ZoomConfig.STEP_SMALL.pixels();
     private final MainView mainView;
     private final JSlider slider;
     private int previousValue;

--- a/src/main/java/carcassonne/view/menubar/ZoomSliderListener.java
+++ b/src/main/java/carcassonne/view/menubar/ZoomSliderListener.java
@@ -17,7 +17,7 @@ import carcassonne.view.main.ZoomMode;
  */
 public class ZoomSliderListener extends MouseAdapter implements ChangeListener {
 
-    private static final double SMOOTHING_FACTOR = 4.0; // only update zoom with this step size.
+    private static final double SMOOTHING_FACTOR = 8.0; // only update zoom with this step size.
     private final MainView mainView;
     private final JSlider slider;
     private int previousValue;

--- a/src/main/java/carcassonne/view/util/ZoomConfig.java
+++ b/src/main/java/carcassonne/view/util/ZoomConfig.java
@@ -4,9 +4,9 @@ package carcassonne.view.util;
  * Defines zoom configuration constants for the game view.
  */
 public enum ZoomConfig {
-    MAX_LEVEL(300),
-    MIN_LEVEL(25),
-    DEFAULT_LEVEL(125),
+    MAX_LEVEL(320),
+    MIN_LEVEL(16),
+    DEFAULT_LEVEL(128),
     STEP(25),
     STEP_SMALL(5);
 

--- a/src/main/java/carcassonne/view/util/ZoomConfig.java
+++ b/src/main/java/carcassonne/view/util/ZoomConfig.java
@@ -1,0 +1,25 @@
+package carcassonne.view.util;
+
+/**
+ * Defines zoom configuration constants for the game view.
+ */
+public enum ZoomConfig {
+    MAX_LEVEL(300),
+    MIN_LEVEL(25),
+    DEFAULT_LEVEL(125),
+    STEP(25),
+    STEP_SMALL(5);
+
+    private final int pixels;
+
+    ZoomConfig(int pixels) {
+        this.pixels = pixels;
+    }
+
+    /*
+     * @return the zoom level constant in pixels.
+     */
+    public int pixels() {
+        return pixels;
+    }
+}

--- a/src/main/java/carcassonne/view/util/ZoomConfig.java
+++ b/src/main/java/carcassonne/view/util/ZoomConfig.java
@@ -4,11 +4,11 @@ package carcassonne.view.util;
  * Defines zoom configuration constants for the game view.
  */
 public enum ZoomConfig {
-    MAX_LEVEL(320),
+    MAX_LEVEL(256),
     MIN_LEVEL(16),
     DEFAULT_LEVEL(128),
-    STEP(25),
-    STEP_SMALL(5);
+    STEP(32),
+    STEP_SMALL(8);
 
     private final int pixels;
 
@@ -16,7 +16,7 @@ public enum ZoomConfig {
         this.pixels = pixels;
     }
 
-    /*
+    /**
      * @return the zoom level constant in pixels.
      */
     public int pixels() {

--- a/src/test/java/carcassonne/util/ConcurrentTileImageScalerTest.java
+++ b/src/test/java/carcassonne/util/ConcurrentTileImageScalerTest.java
@@ -1,0 +1,90 @@
+package carcassonne.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.awt.Image;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import carcassonne.model.tile.TileRotation;
+import org.junit.jupiter.api.BeforeEach;
+
+import carcassonne.model.tile.Tile;
+import carcassonne.model.tile.TileType;
+import carcassonne.view.util.ZoomConfig;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * JUnit 5 test for {@link ConcurrentTileImageScaler}. Tests thread-safety and correctness of concurrent image scaling
+ * operations.
+ */
+class ConcurrentTileImageScalerTest {
+
+    private static final int MIN_SIZE = ZoomConfig.MIN_LEVEL.pixels();
+    private static final int MAX_SIZE = ZoomConfig.MAX_LEVEL.pixels();
+    private static final int STEP_SIZE = ZoomConfig.STEP_SMALL.pixels();
+    private static final int NUM_THREADS = 100;
+    private static final int OPERATIONS_PER_THREAD = 120;
+    public static final int TARGET_SIZE = 128;
+
+    private List<Tile> validTiles;
+
+    @BeforeEach
+    void setUp() {
+        validTiles = TileType.validTiles().stream().map(Tile::new).toList();
+        assertFalse(validTiles.isEmpty(), "Valid tiles list should not be empty");
+    }
+
+    @ParameterizedTest(name = "fast scaling = {0}")
+    @ValueSource(booleans = {true, false})
+    void testGetScaledImage_BasicFunctionality(boolean fastScaling) {
+        Tile tile = validTiles.getFirst();
+        Image image = ConcurrentTileImageScaler.getScaledImage(tile, TARGET_SIZE, fastScaling);
+        checkImageProperties(image, TARGET_SIZE);
+    }
+
+    @ParameterizedTest(name = "fast scaling = {0}")
+    @ValueSource(booleans = {true, false})
+    void testGetScaledMultiResolutionImage_BasicFunctionality(boolean fastScaling) {
+        Tile tile = validTiles.getFirst();
+        Image image = ConcurrentTileImageScaler.getScaledMultiResolutionImage(tile, TARGET_SIZE, fastScaling);
+        checkImageProperties(image, TARGET_SIZE);
+    }
+
+    @ParameterizedTest(name = "fast scaling = {0}")
+    @ValueSource(booleans = {true, false})
+    void testGetScaledImage_Caching(boolean fastScaling) {
+        Tile tile = validTiles.getFirst();
+
+        Image image1 = ConcurrentTileImageScaler.getScaledImage(tile, TARGET_SIZE, fastScaling);
+        Image image2 = ConcurrentTileImageScaler.getScaledImage(tile, TARGET_SIZE, fastScaling);
+
+        checkImageProperties(image1, TARGET_SIZE);
+        checkImageProperties(image2, TARGET_SIZE);
+        assertSame(image1, image2, "Cached images should be the same instance");
+    }
+
+    private static void checkImageProperties(Image image, int targetSize) {
+        assertNotNull(image, "Scaled image should not be null");
+        assertEquals(targetSize, image.getWidth(null), "Image width should match target size");
+        assertEquals(targetSize, image.getHeight(null), "Image height should match target size");
+    }
+
+    private Tile getRandomTile(Random random) {
+        Tile tile = validTiles.get(random.nextInt(validTiles.size()));
+        List<TileRotation> rotations = new ArrayList<>(tile.getPossibleRotations());
+        if (!rotations.isEmpty()) {
+            int index = random.nextInt(rotations.size());
+            tile.rotateTo(rotations.get(index));
+        }
+        return tile;
+    }
+
+    private int getRandomSize(Random rng) {
+        int numSteps = (MAX_SIZE - MIN_SIZE) / STEP_SIZE;
+        int randomStep = rng.nextInt(numSteps + 1);
+        return MIN_SIZE + (randomStep * STEP_SIZE);
+    }
+}

--- a/src/test/java/carcassonne/util/ConcurrentTileImageScalerTest.java
+++ b/src/test/java/carcassonne/util/ConcurrentTileImageScalerTest.java
@@ -4,11 +4,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.awt.GraphicsEnvironment;
 import java.awt.Image;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +24,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import carcassonne.model.tile.Tile;
+import carcassonne.model.tile.TileRotation;
 import carcassonne.model.tile.TileType;
 import carcassonne.view.util.ZoomConfig;
 
@@ -25,12 +34,12 @@ import carcassonne.view.util.ZoomConfig;
  */
 class ConcurrentTileImageScalerTest {
 
-    public static final String AWT_HEADLESS_PROPERTY = "java.awt.headless";
     private static final int MIN_SIZE = ZoomConfig.MIN_LEVEL.pixels();
     private static final int MAX_SIZE = ZoomConfig.MAX_LEVEL.pixels();
     private static final int STEP_SIZE = ZoomConfig.STEP_SMALL.pixels();
-    private static final int NUM_THREADS = 100;
-    private static final int OPERATIONS_PER_THREAD = 120;
+
+    private static final int THREAD_COUNT = 200;
+    private static final int OPERATIONS_PER_THREAD = 300;
     public static final int TARGET_SIZE = 128;
 
     private List<Tile> validTiles;
@@ -51,7 +60,7 @@ class ConcurrentTileImageScalerTest {
     void testGetScaledImage_BasicFunctionality(boolean fastScaling) {
         Tile tile = validTiles.getFirst();
         Image image = ConcurrentTileImageScaler.getScaledImage(tile, TARGET_SIZE, fastScaling);
-        checkImageProperties(image, TARGET_SIZE);
+        checkImageProperties(image);
     }
 
     @ParameterizedTest(name = "fast scaling = {0}")
@@ -59,7 +68,7 @@ class ConcurrentTileImageScalerTest {
     void testGetScaledMultiResolutionImage_BasicFunctionality(boolean fastScaling) {
         Tile tile = validTiles.getFirst();
         Image image = ConcurrentTileImageScaler.getScaledMultiResolutionImage(tile, TARGET_SIZE, fastScaling);
-        checkImageProperties(image, TARGET_SIZE);
+        checkImageProperties(image);
     }
 
     @ParameterizedTest(name = "fast scaling = {0}")
@@ -70,14 +79,97 @@ class ConcurrentTileImageScalerTest {
         Image image1 = ConcurrentTileImageScaler.getScaledImage(tile, TARGET_SIZE, fastScaling);
         Image image2 = ConcurrentTileImageScaler.getScaledImage(tile, TARGET_SIZE, fastScaling);
 
-        checkImageProperties(image1, TARGET_SIZE);
-        checkImageProperties(image2, TARGET_SIZE);
+        checkImageProperties(image1);
+        checkImageProperties(image2);
         assertSame(image1, image2, "Cached images should be the same instance!");
     }
 
-    private static void checkImageProperties(Image image, int targetSize) {
+    private static void checkImageProperties(Image image) {
         assertNotNull(image, "Scaled image should not be null");
-        assertEquals(targetSize, image.getWidth(null), "Image width should match target size!");
-        assertEquals(targetSize, image.getHeight(null), "Image height should match target size!");
+        assertEquals(TARGET_SIZE, image.getWidth(null), "Image width should match target size!");
+        assertEquals(TARGET_SIZE, image.getHeight(null), "Image height should match target size!");
+    }
+
+    @ParameterizedTest(name = "fast scaling = {0}")
+    @ValueSource(booleans = {true, false})
+    void testConcurrentScaling(boolean fastScaling) throws InterruptedException {
+        try (ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT)) {
+            CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+            AtomicInteger exceptionCount = new AtomicInteger(0);
+            List<Tile> tiles = createTestTiles();
+
+            for (int i = 0; i < THREAD_COUNT; i++) {
+                executor.submit(() -> {
+                    try {
+                        Random random = new Random();
+                        for (int j = 0; j < OPERATIONS_PER_THREAD; j++) {
+                            Tile tile = tiles.get(random.nextInt(tiles.size()));
+                            int targetSize = MIN_SIZE + STEP_SIZE * random.nextInt((MAX_SIZE - MIN_SIZE) / STEP_SIZE + 1);
+
+                            Image image = ConcurrentTileImageScaler.getScaledImage(tile, targetSize, fastScaling);
+                            assertNotNull(image, "Scaled image should not be null");
+                        }
+                    } catch (Exception e) {
+                        exceptionCount.incrementAndGet();
+                        e.printStackTrace();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            assertTrue(latch.await(30, TimeUnit.SECONDS), "Test should complete within timeout");
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS), "Executor should terminate");
+
+            assertEquals(0, exceptionCount.get(), "No exceptions should occur during concurrent scaling");
+        }
+    }
+
+    @ParameterizedTest(name = "fast scaling = {0}")
+    @ValueSource(booleans = {true, false})
+    void testConcurrentMultiResolutionScaling(boolean fastScaling) throws InterruptedException {
+        try (ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT)) {
+            CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+            AtomicInteger exceptionCount = new AtomicInteger(0);
+            List<Tile> tiles = createTestTiles();
+
+            for (int i = 0; i < THREAD_COUNT; i++) {
+                executor.submit(() -> {
+                    try {
+                        Random random = new Random();
+                        for (int j = 0; j < OPERATIONS_PER_THREAD; j++) {
+                            Tile tile = tiles.get(random.nextInt(tiles.size()));
+                            int targetSize = MIN_SIZE + STEP_SIZE * random.nextInt((MAX_SIZE - MIN_SIZE) / STEP_SIZE + 1);
+
+                            Image image = ConcurrentTileImageScaler.getScaledMultiResolutionImage(tile, targetSize, fastScaling);
+                            assertNotNull(image, "Multi-resolution image should not be null");
+                        }
+                    } catch (Exception e) {
+                        exceptionCount.incrementAndGet();
+                        e.printStackTrace();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            assertTrue(latch.await(60, TimeUnit.SECONDS), "Test should complete within timeout");
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS), "Executor should terminate");
+            assertEquals(0, exceptionCount.get(), "No exceptions should occur during concurrent multi-resolution scaling");
+        }
+    }
+
+    private List<Tile> createTestTiles() {
+        List<Tile> tiles = new ArrayList<>();
+        for (TileType type : TileType.validTiles()) {
+            for (TileRotation rotation : TileRotation.values()) {
+                Tile tile = new Tile(type);
+                tile.rotateTo(rotation);
+                tiles.add(tile);
+            }
+        }
+        return tiles;
     }
 }

--- a/src/test/java/carcassonne/util/ConcurrentTileImageScalerTest.java
+++ b/src/test/java/carcassonne/util/ConcurrentTileImageScalerTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Random;
 
 import carcassonne.model.tile.TileRotation;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
 import carcassonne.model.tile.Tile;
@@ -22,6 +23,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  */
 class ConcurrentTileImageScalerTest {
 
+    public static final String AWT_HEADLESS_PROPERTY = "java.awt.headless";
     private static final int MIN_SIZE = ZoomConfig.MIN_LEVEL.pixels();
     private static final int MAX_SIZE = ZoomConfig.MAX_LEVEL.pixels();
     private static final int STEP_SIZE = ZoomConfig.STEP_SMALL.pixels();
@@ -30,6 +32,11 @@ class ConcurrentTileImageScalerTest {
     public static final int TARGET_SIZE = 128;
 
     private List<Tile> validTiles;
+
+    @BeforeAll
+    static void headless() {
+        System.setProperty(AWT_HEADLESS_PROPERTY, Boolean.toString(true));
+    }
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/carcassonne/util/ConcurrentTileImageScalerTest.java
+++ b/src/test/java/carcassonne/util/ConcurrentTileImageScalerTest.java
@@ -1,21 +1,23 @@
 package carcassonne.util;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+import java.awt.GraphicsEnvironment;
 import java.awt.Image;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
-import carcassonne.model.tile.TileRotation;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import carcassonne.model.tile.Tile;
 import carcassonne.model.tile.TileType;
 import carcassonne.view.util.ZoomConfig;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * JUnit 5 test for {@link ConcurrentTileImageScaler}. Tests thread-safety and correctness of concurrent image scaling
@@ -34,14 +36,14 @@ class ConcurrentTileImageScalerTest {
     private List<Tile> validTiles;
 
     @BeforeAll
-    static void headless() {
-        System.setProperty(AWT_HEADLESS_PROPERTY, Boolean.toString(true));
+    static void requireHeadfulAwt() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Requires headful AWT to run.");
     }
 
     @BeforeEach
     void setUp() {
         validTiles = TileType.validTiles().stream().map(Tile::new).toList();
-        assertFalse(validTiles.isEmpty(), "Valid tiles list should not be empty");
+        assertFalse(validTiles.isEmpty(), "Valid tiles list should not be empty!");
     }
 
     @ParameterizedTest(name = "fast scaling = {0}")
@@ -70,28 +72,12 @@ class ConcurrentTileImageScalerTest {
 
         checkImageProperties(image1, TARGET_SIZE);
         checkImageProperties(image2, TARGET_SIZE);
-        assertSame(image1, image2, "Cached images should be the same instance");
+        assertSame(image1, image2, "Cached images should be the same instance!");
     }
 
     private static void checkImageProperties(Image image, int targetSize) {
         assertNotNull(image, "Scaled image should not be null");
-        assertEquals(targetSize, image.getWidth(null), "Image width should match target size");
-        assertEquals(targetSize, image.getHeight(null), "Image height should match target size");
-    }
-
-    private Tile getRandomTile(Random random) {
-        Tile tile = validTiles.get(random.nextInt(validTiles.size()));
-        List<TileRotation> rotations = new ArrayList<>(tile.getPossibleRotations());
-        if (!rotations.isEmpty()) {
-            int index = random.nextInt(rotations.size());
-            tile.rotateTo(rotations.get(index));
-        }
-        return tile;
-    }
-
-    private int getRandomSize(Random rng) {
-        int numSteps = (MAX_SIZE - MIN_SIZE) / STEP_SIZE;
-        int randomStep = rng.nextInt(numSteps + 1);
-        return MIN_SIZE + (randomStep * STEP_SIZE);
+        assertEquals(targetSize, image.getWidth(null), "Image width should match target size!");
+        assertEquals(targetSize, image.getHeight(null), "Image height should match target size!");
     }
 }


### PR DESCRIPTION
This pull request improves HighDPI rendering and enhances the window sizing for the main application window:

- Fix a bug where moving the window to another monitor resulted in the window resizing to huge dimensions. 
- Fix rendering issues for scaling uneven scaling factor percentages (e.g., 125%). This resulted in grainy tiles rendering for common multi-monitor setups with Windows systems. Note that macOS was not affected.
- Ensure that zoom levels also promote smooth rendering by using even-numbered pixel values. As part of this, the zoom steps and the max. zoom level is slightly adjusted.
- Increase the default grid size to 45x27.
- Add test class for the tile image scaler